### PR TITLE
Fix the inferring of the modified cluster

### DIFF
--- a/nanocompore/comparisons.py
+++ b/nanocompore/comparisons.py
@@ -585,24 +585,12 @@ class TranscriptComparator:
         """
         depleted_cond = self._config.get_depleted_condition()
         depleted_cond_id = self._config.get_condition_ids()[depleted_cond]
+        ctrl_cond_id = 1 - depleted_cond_id
 
-        cond_counts = contingency.sum(2).to(torch.uint32)
-        # contingency will be something like this:
-        # e.g.      cluster
-        # condition   0   1
-        #         0  100  30
-        #         1   90  40
-        freq_contingency = contingency / cond_counts.unsqueeze(2)
+        ctrl0dep1 = contingency[:, ctrl_cond_id, 0] * contingency[:, depleted_cond_id, 1]
+        ctrl1dep0 = contingency[:, ctrl_cond_id, 1] * contingency[:, depleted_cond_id, 0]
 
-        # We assume that the unmodified cluster is the one
-        # in which the depleted condition has most of its
-        # points. Hence, the modified is the one, where
-        # the depleted condition has fewer points.
-        # I.e. if the condition 0 is the depleted one,
-        # in the example contingency above the modified
-        # cluster will be cluster 1.
-        mod_clusters = freq_contingency[:, depleted_cond_id, :].argmin(1)
-        return mod_clusters
+        return torch.where(ctrl0dep1 > ctrl1dep0, 0, 1)
 
 
     def retry(self, fn, delay=5, backoff=5, max_attempts=3, exception=Exception):

--- a/tests/test_comparisons.py
+++ b/tests/test_comparisons.py
@@ -312,12 +312,17 @@ def test_get_cluster_counts():
     # are found in cluster 1, then we can guess that the
     # modification cluster is 1.
     # For the third, cluster 0 will be the modified one.
+    # The fourth position tests the case in which most reads
+    # from both conditions are assigned to the modified cluster,
+    # even the majority of the points for the depleted condition
+    # are assigned to it.
     conditions = torch.tensor([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1])
     samples = torch.tensor([0, 0, 1, 1, 1, 2, 2, 3, 3, 3, 3])
     # We have predictions for three positions.
     predictions = torch.tensor([[0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 1],
                                 [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
-                                [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0]])
+                                [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+                                [1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1]])
 
     contingency = get_contingency_matrices(conditions, predictions)
 
@@ -325,14 +330,14 @@ def test_get_cluster_counts():
 
     cluster_counts = comparator._get_cluster_counts(contingency, samples, predictions)
 
-    assert np.all(cluster_counts['kd1_mod'] == np.array([0, 0, 0]))
-    assert np.all(cluster_counts['kd2_mod'] == np.array([1, 0, 0]))
-    assert np.all(cluster_counts['wt1_mod'] == np.array([1, 2, 2]))
-    assert np.all(cluster_counts['wt2_mod'] == np.array([3, 4, 4]))
-    assert np.all(cluster_counts['kd1_unmod'] == np.array([2, 2, 2]))
-    assert np.all(cluster_counts['kd2_unmod'] == np.array([2, 3, 3]))
-    assert np.all(cluster_counts['wt1_unmod'] == np.array([1, 0, 0]))
-    assert np.all(cluster_counts['wt2_unmod'] == np.array([1, 0, 0]))
+    assert np.all(cluster_counts['kd1_mod'] == np.array([0, 0, 0, 2]))
+    assert np.all(cluster_counts['kd2_mod'] == np.array([1, 0, 0, 1]))
+    assert np.all(cluster_counts['wt1_mod'] == np.array([1, 2, 2, 2]))
+    assert np.all(cluster_counts['wt2_mod'] == np.array([3, 4, 4, 4]))
+    assert np.all(cluster_counts['kd1_unmod'] == np.array([2, 2, 2, 0]))
+    assert np.all(cluster_counts['kd2_unmod'] == np.array([2, 3, 3, 2]))
+    assert np.all(cluster_counts['wt1_unmod'] == np.array([1, 0, 0, 0]))
+    assert np.all(cluster_counts['wt2_unmod'] == np.array([1, 0, 0, 0]))
 
 
 def test_get_soft_cluster_counts():


### PR DESCRIPTION
The old version was assuming that the modified cluster is the one to which a smaller portion of the depleted condition's reads are assigned to.  In some cases this doesn't work well (e.g. if the clusters are unbalanced, the smaller one will be assumed to be the modified, because the majority of the reads for the depleted condition are in the bigger one, even if the bigger one is enriched for the non-depleted condition).

Here we change the strategy to infer the modified cluster in a way that considers both conditions so that the depleted condition is enriched in the non-modified cluster and the non-depleted condition is enriched in the modified cluster.